### PR TITLE
feature: add QueueOwnerAWSAccountId option to allow sending messages to different AWS account

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,10 @@ This library is available at Maven Central repository, so you can reference it i
 It's easy to get lost while understanding all the classes are needed, so we can create a custom sink for Spark. Here's a class diagram to make it a little easy to find yourself. Start at SQSSinkProvider, it's the class that we configure in Spark code as a *format* method's value.
 
 ![Class diagram showing all the classes needed to implement a custom sink](/doc/assets/Class%20Diagram-Page-1.png "Class diagram showing all the classes needed to implement a custom sink")
+
+## Sending messages to a queue in another AWS Account
+You might have an architecture where the Spark job and the SQS are in different AWS accounts. In that case, you can specify one extra option to make the writer aware of which account to use.
+
+```java
+.option("queueOwnerAWSAccountId", "123456789012")
+```

--- a/spark-aws-messaging/src/main/java/com/fabiogouw/spark/awsmessaging/sqs/SQSSinkDataWriter.java
+++ b/spark-aws-messaging/src/main/java/com/fabiogouw/spark/awsmessaging/sqs/SQSSinkDataWriter.java
@@ -23,6 +23,7 @@ public class SQSSinkDataWriter implements DataWriter<InternalRow> {
     private final List<SendMessageBatchRequestEntry> messages = new ArrayList<SendMessageBatchRequestEntry>();
     private final int batchMaxSize;
     private final String queueUrl;
+    private final String queueOwnerAWSAccountId;
     private final int valueColumnIndex;
     private final int msgAttributesColumnIndex;
 
@@ -31,13 +32,20 @@ public class SQSSinkDataWriter implements DataWriter<InternalRow> {
                              AmazonSQS sqs,
                              int batchMaxSize,
                              String queueName,
+                             String queueOwnerAWSAccountId,
                              int valueColumnIndex,
                              int msgAttributesColumnIndex) {
         this.partitionId = partitionId;
         this.taskId = taskId;
         this.batchMaxSize = batchMaxSize;
         this.sqs = sqs;
-        queueUrl = sqs.getQueueUrl(queueName).getQueueUrl();
+        queueUrlRequest = sqs.GetQueueUrlRequest();
+        queueUrlRequest.setQueueName(queueName);
+        if(!queueOwnerAWSAccountId.isEmpty()) {
+            queueUrlRequest.setQueueOwnerAWSAccountId(queueOwnerAWSAccountId);
+        }
+        queueUrlRequest.setQueueOwnerAWSAccountId(queueOwnerAWSAccountId);
+        queueUrl = sqs.getQueueUrl(queueUrlRequest).getQueueUrl();
         this.valueColumnIndex = valueColumnIndex;
         this.msgAttributesColumnIndex = msgAttributesColumnIndex;
     }

--- a/spark-aws-messaging/src/main/java/com/fabiogouw/spark/awsmessaging/sqs/SQSSinkDataWriterFactory.java
+++ b/spark-aws-messaging/src/main/java/com/fabiogouw/spark/awsmessaging/sqs/SQSSinkDataWriterFactory.java
@@ -33,6 +33,7 @@ public class SQSSinkDataWriterFactory implements DataWriterFactory {
                 sqs,
                 options.getBatchSize(),
                 options.getQueueName(),
+                options.getQueueOwnerAWSAccountId(),
                 options.getValueColumnIndex(),
                 options.getMsgAttributesColumnIndex());
     }

--- a/spark-aws-messaging/src/main/java/com/fabiogouw/spark/awsmessaging/sqs/SQSSinkOptions.java
+++ b/spark-aws-messaging/src/main/java/com/fabiogouw/spark/awsmessaging/sqs/SQSSinkOptions.java
@@ -11,6 +11,7 @@ public class SQSSinkOptions implements Serializable {
     private final String region;
     private final String endpoint;
     private final String queueName;
+    private final String queueOwnerAWSAccountId;
     private final int batchSize;
     private final Service service;
     private final int valueColumnIndex;
@@ -19,6 +20,7 @@ public class SQSSinkOptions implements Serializable {
     public SQSSinkOptions(String region,
                           String endpoint,
                           String queueName,
+                          String queueOwnerAWSAccountId,
                           int batchSize,
                           Service service,
                           int valueColumnIndex,
@@ -26,6 +28,7 @@ public class SQSSinkOptions implements Serializable {
         this.region = region != null ? region : "us-east-1";
         this.endpoint = endpoint != null ? endpoint : "";
         this.queueName = queueName != null ? queueName : "";
+        this.queueOwnerAWSAccountId = queueOwnerAWSAccountId != null ? queueOwnerAWSAccountId : "";
         this.batchSize = batchSize;
         this.service = service;
         this.valueColumnIndex = valueColumnIndex;
@@ -58,5 +61,9 @@ public class SQSSinkOptions implements Serializable {
 
     public int getMsgAttributesColumnIndex() {
         return msgAttributesColumnIndex;
+    }
+
+    public int getQueueOwnerAWSAccountId() {
+        return QueueOwnerAWSAccountId;
     }
 }

--- a/spark-aws-messaging/src/main/java/com/fabiogouw/spark/awsmessaging/sqs/SQSSinkWriteBuilder.java
+++ b/spark-aws-messaging/src/main/java/com/fabiogouw/spark/awsmessaging/sqs/SQSSinkWriteBuilder.java
@@ -26,6 +26,7 @@ public class SQSSinkWriteBuilder implements WriteBuilder {
                 info.options().get("region"),
                 info.options().get("endpoint"),
                 info.options().get("queueName"),
+                info.options().get("queueOwnerAWSAccountId"),
                 batchSize,
                 service,
                 schema.fieldIndex(valueColumnName),


### PR DESCRIPTION
Hey @fabiogouw,

Just opening a PR related to issue #2.

I don't have much Java experience and don't know if what I did is correct. Please feel free to suggest changes or improve the proposed changes.

The whole idea is to add a new option called `queueOwnerAWSAccountId` that will contain a string with the AWS account id of the queue owner. It must be optional, in case the queue is in the same account as the spark job.

This parameter is then used to get the queue URL, making it account aware.

I didn't build or write unit tests because I have zero experience with that in Java.
