### PR TITLE
Support FIFO SQS queues via .withMessageGroupId()

### DIFF
--- a/spark-aws-messaging/src/main/java/com/fabiogouw/spark/awsmessaging/sqs/SQSSinkDataWriter.java
+++ b/spark-aws-messaging/src/main/java/com/fabiogouw/spark/awsmessaging/sqs/SQSSinkDataWriter.java
@@ -27,6 +27,7 @@ public class SQSSinkDataWriter implements DataWriter<InternalRow> {
     private final String queueOwnerAWSAccountId;
     private final int valueColumnIndex;
     private final int msgAttributesColumnIndex;
+    private final int groupIdColumnIndex;
 
     public SQSSinkDataWriter(int partitionId,
                              long taskId,
@@ -35,7 +36,8 @@ public class SQSSinkDataWriter implements DataWriter<InternalRow> {
                              String queueName,
                              String queueOwnerAWSAccountId,
                              int valueColumnIndex,
-                             int msgAttributesColumnIndex) {
+                             int msgAttributesColumnIndex,
+                             int groupIdColumnIndex) {
         this.partitionId = partitionId;
         this.taskId = taskId;
         this.batchMaxSize = batchMaxSize;
@@ -48,6 +50,7 @@ public class SQSSinkDataWriter implements DataWriter<InternalRow> {
         queueUrl = sqs.getQueueUrl(queueUrlRequest).getQueueUrl();
         this.valueColumnIndex = valueColumnIndex;
         this.msgAttributesColumnIndex = msgAttributesColumnIndex;
+        this.groupIdColumnIndex = groupIdColumnIndex;
     }
 
     @Override
@@ -56,8 +59,10 @@ public class SQSSinkDataWriter implements DataWriter<InternalRow> {
         if(msgAttributesColumnIndex > 0) {
             arrayData = Optional.of(record.getArray(msgAttributesColumnIndex));
         }
+        String groupId = groupIdColumnIndex > 0 ? record.getString(groupIdColumnIndex) : null;
         SendMessageBatchRequestEntry msg = new SendMessageBatchRequestEntry()
                 .withMessageBody(record.getString(valueColumnIndex))
+                .withMessageGroupId(groupId)
                 .withMessageAttributes(convertMapData(arrayData))
                 .withId(UUID.randomUUID().toString());
         messages.add(msg);

--- a/spark-aws-messaging/src/main/java/com/fabiogouw/spark/awsmessaging/sqs/SQSSinkDataWriterFactory.java
+++ b/spark-aws-messaging/src/main/java/com/fabiogouw/spark/awsmessaging/sqs/SQSSinkDataWriterFactory.java
@@ -35,6 +35,7 @@ public class SQSSinkDataWriterFactory implements DataWriterFactory {
                 options.getQueueName(),
                 options.getQueueOwnerAWSAccountId(),
                 options.getValueColumnIndex(),
-                options.getMsgAttributesColumnIndex());
+                options.getMsgAttributesColumnIndex(),
+                options.getGroupIdColumnIndex());
     }
 }

--- a/spark-aws-messaging/src/main/java/com/fabiogouw/spark/awsmessaging/sqs/SQSSinkOptions.java
+++ b/spark-aws-messaging/src/main/java/com/fabiogouw/spark/awsmessaging/sqs/SQSSinkOptions.java
@@ -16,6 +16,7 @@ public class SQSSinkOptions implements Serializable {
     private final Service service;
     private final int valueColumnIndex;
     private final int msgAttributesColumnIndex;
+    private final int groupIdColumnIndex;
 
     public SQSSinkOptions(String region,
                           String endpoint,
@@ -24,7 +25,8 @@ public class SQSSinkOptions implements Serializable {
                           int batchSize,
                           Service service,
                           int valueColumnIndex,
-                          int msgAttributesColumnIndex) {
+                          int msgAttributesColumnIndex,
+                          int groupIdColumnIndex) {
         this.region = region != null ? region : "us-east-1";
         this.endpoint = endpoint != null ? endpoint : "";
         this.queueName = queueName != null ? queueName : "";
@@ -33,6 +35,7 @@ public class SQSSinkOptions implements Serializable {
         this.service = service;
         this.valueColumnIndex = valueColumnIndex;
         this.msgAttributesColumnIndex = msgAttributesColumnIndex;
+        this.groupIdColumnIndex = groupIdColumnIndex;
     }
 
     public String getRegion() {
@@ -61,6 +64,10 @@ public class SQSSinkOptions implements Serializable {
 
     public int getMsgAttributesColumnIndex() {
         return msgAttributesColumnIndex;
+    }
+
+    public int getGroupIdColumnIndex() {
+        return groupIdColumnIndex;
     }
 
     public String getQueueOwnerAWSAccountId() {

--- a/spark-aws-messaging/src/main/java/com/fabiogouw/spark/awsmessaging/sqs/SQSSinkWriteBuilder.java
+++ b/spark-aws-messaging/src/main/java/com/fabiogouw/spark/awsmessaging/sqs/SQSSinkWriteBuilder.java
@@ -30,7 +30,8 @@ public class SQSSinkWriteBuilder implements WriteBuilder {
                 batchSize,
                 service,
                 schema.fieldIndex(valueColumnName),
-                schema.getFieldIndex(messageAttributesColumnName).isEmpty() ? -1 : schema.fieldIndex(messageAttributesColumnName)
+                schema.getFieldIndex(messageAttributesColumnName).isEmpty() ? -1 : schema.fieldIndex(messageAttributesColumnName),
+                schema.getFieldIndex(groupIdColumnName).isEmpty() ? -1 : schema.fieldIndex(groupIdColumnName)
                 );
         return new SQSSinkBatchWrite(options);
     }


### PR DESCRIPTION
To write messages into a FIFO queue from Spark, we should set the MessageGroupId as a parameter of the SendMessageRequest.

I naively tried setting MessageGroupId with the existing msg_attributes parameter, but it doesn't work with SQS. We cannot set the `MessageGroupId` using `withMessageAttributes`. The `MessageGroupId` is a specific parameter used by Amazon SQS to group and order messages in a FIFO queue [docs.aws.amazon.com][0]. It is not the same as a message attribute, which is custom metadata that you can attach to a message.

[0]: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagegroupid-property.html

@fabiogouw - please let me know if there are any changes you would like made, or any improvements. I made the bare minimum change necessary to support my use case. Which is a FIFO with content-based duplication turned on. So, I did not need support for any additional fields except  MessageGroupId. I suspect we may want to add that support in separate follow-up pull requests.

I was also curious, if this is accepted, would it be possible to deploy this to maven so I it could be used downstream?