### PR TITLE
Image versioning for tests

### DIFF
--- a/spark-aws-messaging/src/test/java/com/fabiogouw/spark/awsmessaging/sqs/Spark3_1_2IntegrationTest.java
+++ b/spark-aws-messaging/src/test/java/com/fabiogouw/spark/awsmessaging/sqs/Spark3_1_2IntegrationTest.java
@@ -1,0 +1,11 @@
+package com.fabiogouw.spark.awsmessaging.sqs;
+
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public class Spark3_1_2IntegrationTest extends SparkIntegrationTest {
+
+    public Spark3_1_2IntegrationTest() {
+        super("bitnami/spark:3.1.2");
+    }
+}

--- a/spark-aws-messaging/src/test/java/com/fabiogouw/spark/awsmessaging/sqs/Spark3_3_2IntegrationTest.java
+++ b/spark-aws-messaging/src/test/java/com/fabiogouw/spark/awsmessaging/sqs/Spark3_3_2IntegrationTest.java
@@ -1,0 +1,11 @@
+package com.fabiogouw.spark.awsmessaging.sqs;
+
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public class Spark3_3_2IntegrationTest extends SparkIntegrationTest {
+
+    public Spark3_3_2IntegrationTest() {
+        super("bitnami/spark:3.3.2");
+    }
+}

--- a/spark-aws-messaging/src/test/java/com/fabiogouw/spark/awsmessaging/sqs/Spark3_5_1IntegrationTest.java
+++ b/spark-aws-messaging/src/test/java/com/fabiogouw/spark/awsmessaging/sqs/Spark3_5_1IntegrationTest.java
@@ -1,0 +1,11 @@
+package com.fabiogouw.spark.awsmessaging.sqs;
+
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public class Spark3_5_1IntegrationTest extends SparkIntegrationTest {
+
+    public Spark3_5_1IntegrationTest() {
+        super("bitnami/spark:3.5.1");
+    }
+}


### PR DESCRIPTION
Since this library can be used by different Spark versions, I'm adding this capability of running the same integration test set against specific versions of Spark (3.1.2, 3.3.2 and 3.5.1).

This will slow down the building process, but will increase the confidence in releasing new versions of this library.